### PR TITLE
:fire: Disable noSuchMethod trap

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.7.0"
+  "version": "0.8.0"
 }

--- a/packages/nodepay-bpoint/package.json
+++ b/packages/nodepay-bpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-bpoint",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",
@@ -64,7 +64,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@atomixdesign/nodepay-core": "^0.7.0",
+    "@atomixdesign/nodepay-core": "^0.8.0",
     "@types/debug": "^4.1.5",
     "axios": "^0.19.2",
     "class-validator": "^0.12.2",

--- a/packages/nodepay-core/package.json
+++ b/packages/nodepay-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",

--- a/packages/nodepay-core/src/context.ts
+++ b/packages/nodepay-core/src/context.ts
@@ -107,27 +107,4 @@ export class Context implements
       ...arguments_
     })
   }
-
-  __noSuchMethod__(name: string, arguments_: any): any {
-    log('warning: no such method on standard interface')
-    log(`non-standard method ${name} called on ${this.gateway.constructor.name}`)
-    log('attempting dispatch')
-    return this.dispatch(name, {
-      ...arguments_,
-    })
-  }
-}
-
-function augmentWithNoSuchMethod(object: any) {
-  return new Proxy(object, {
-    get(target, p) {
-      if (p in target || p in new Promise(() => {})) {
-        return target[p]
-      } else if (typeof target.__noSuchMethod__ == 'function') {
-        return function(...arguments_: any) {
-          return target.__noSuchMethod__.call(target, p, arguments_)
-        }
-      }
-    }
-  })
 }

--- a/packages/nodepay-core/src/context.ts
+++ b/packages/nodepay-core/src/context.ts
@@ -26,9 +26,7 @@ export class Context implements
   RecurringPayment
 {
   [x: string]: any
-  constructor(private gateway?: any) {
-    return augmentWithNoSuchMethod(this)
-  }
+  constructor(private gateway?: any) {}
 
   public use(adapter: any): void {
     this.gateway = adapter

--- a/packages/nodepay-ezidebit/package.json
+++ b/packages/nodepay-ezidebit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-ezidebit",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",
@@ -64,7 +64,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@atomixdesign/nodepay-core": "^0.7.0",
+    "@atomixdesign/nodepay-core": "^0.8.0",
     "@types/debug": "^4.1.5",
     "class-validator": "^0.12.2",
     "debug": "^4.2.0",

--- a/packages/nodepay-fatzebra/package.json
+++ b/packages/nodepay-fatzebra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-fatzebra",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",
@@ -65,7 +65,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@atomixdesign/nodepay-core": "^0.7.0",
+    "@atomixdesign/nodepay-core": "^0.8.0",
     "@types/debug": "^4.1.5",
     "axios": "^0.19.2",
     "class-validator": "^0.12.2",

--- a/packages/nodepay-pay-way/package.json
+++ b/packages/nodepay-pay-way/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-pay-way",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",
@@ -65,7 +65,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@atomixdesign/nodepay-core": "^0.7.0",
+    "@atomixdesign/nodepay-core": "^0.8.0",
     "@types/debug": "^4.1.5",
     "@types/qs": "^6.9.3",
     "@types/uuid": "^8.0.0",

--- a/packages/nodepay-paystream/package.json
+++ b/packages/nodepay-paystream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-paystream",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",
@@ -65,7 +65,7 @@
     "typescript": "^3.9.3"
   },
   "dependencies": {
-    "@atomixdesign/nodepay-core": "^0.7.0",
+    "@atomixdesign/nodepay-core": "^0.8.0",
     "@types/debug": "^4.1.5",
     "axios": "^0.19.2",
     "class-validator": "^0.12.2",


### PR DESCRIPTION
The NoSuchMethod trap is used only with legacy paystream. At the moment, the implementation appears to also cause multiple instances of Nodepay to share a common config, or persist some information from the context/config.

Removing as obsolete.