### PR TITLE
:fire: Refactor settings manager into an instance member

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.10.9"
+  "version": "0.11.0"
 }

--- a/packages/nodepay-bpoint/package.json
+++ b/packages/nodepay-bpoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-bpoint",
-  "version": "0.10.9",
+  "version": "0.11.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",
@@ -64,7 +64,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@atomixdesign/nodepay-core": "^0.10.9",
+    "@atomixdesign/nodepay-core": "^0.11.0",
     "@types/debug": "^4.1.5",
     "axios": "^0.21.1",
     "class-validator": "^0.13.1",

--- a/packages/nodepay-core/package.json
+++ b/packages/nodepay-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-core",
-  "version": "0.10.9",
+  "version": "0.11.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",

--- a/packages/nodepay-core/src/context.ts
+++ b/packages/nodepay-core/src/context.ts
@@ -1,4 +1,3 @@
-import Container, { Service } from 'typedi'
 import {
   CustomerDetails,
   DirectDebit,
@@ -15,7 +14,6 @@ import {
 import { IBaseResponse } from './network'
 
 import debug from 'debug'
-import { runMode, SettingsManager } from './settings'
 import { BaseGateway } from './gateways'
 const log = debug('nodepay:core')
 
@@ -23,7 +21,6 @@ const _hasOwnProperty = (object: any, methodName: string) => {
   return Object.prototype.hasOwnProperty.call(object, methodName)
 }
 
-@Service()
 export class Context implements
   CustomerDetails,
   DirectDebit,
@@ -33,18 +30,11 @@ export class Context implements
   [x: string]: any
 
   constructor(private gateway?: any) {
-    Container.set(SettingsManager, new SettingsManager())
-
     return augmentWithNoSuchMethod(this)
   }
 
   public use(adapter: BaseGateway): void {
     this.gateway = adapter
-  }
-
-  public setRunMode(runMode: string): void {
-    const settingsManager = Container.get(SettingsManager)
-    settingsManager.runMode = runMode as runMode
   }
 
   public get name(): string {

--- a/packages/nodepay-core/src/gateways/base-gateway.ts
+++ b/packages/nodepay-core/src/gateways/base-gateway.ts
@@ -1,9 +1,13 @@
+import { SettingsManager } from '../settings'
+
 export abstract class BaseGateway<T extends Record<string, unknown> = Record<string, unknown>, P = Partial<T>> {
   abstract get shortName(): string
   abstract get name(): string
 
   protected abstract get baseConfig(): T
   public readonly config: T
+
+  public settingsManager: SettingsManager = new SettingsManager()
 
   constructor(config?: P) {
     this.config = this.buildConfig(config)

--- a/packages/nodepay-core/src/settings/settings-manager.ts
+++ b/packages/nodepay-core/src/settings/settings-manager.ts
@@ -1,7 +1,5 @@
-import { Service } from 'typedi'
-
 export type runMode = 'dry' | 'verbose' | 'wet'
-@Service()
+
 export class SettingsManager {
   private _runMode: runMode = 'wet'
 

--- a/packages/nodepay-ezidebit/package.json
+++ b/packages/nodepay-ezidebit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-ezidebit",
-  "version": "0.10.9",
+  "version": "0.11.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",
@@ -64,7 +64,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@atomixdesign/nodepay-core": "^0.10.9",
+    "@atomixdesign/nodepay-core": "^0.11.0",
     "@types/debug": "^4.1.5",
     "class-validator": "^0.13.1",
     "debug": "^4.3.1",

--- a/packages/nodepay-fatzebra/package.json
+++ b/packages/nodepay-fatzebra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-fatzebra",
-  "version": "0.10.9",
+  "version": "0.11.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",
@@ -65,7 +65,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@atomixdesign/nodepay-core": "^0.10.9",
+    "@atomixdesign/nodepay-core": "^0.11.0",
     "@types/debug": "^4.1.5",
     "axios": "^0.21.1",
     "class-validator": "^0.13.1",

--- a/packages/nodepay-fatzebra/src/fatzebra.ts
+++ b/packages/nodepay-fatzebra/src/fatzebra.ts
@@ -1,6 +1,5 @@
-import Container, { Service } from 'typedi'
 import { validateOrReject } from 'class-validator'
-import { BaseGateway, SettingsManager } from '@atomixdesign/nodepay-core'
+import { BaseGateway } from '@atomixdesign/nodepay-core'
 import {
   OnceOffPayment,
   RecurringPayment,
@@ -22,15 +21,12 @@ import {
 } from './transport/dtos'
 import { FatzebraAPI } from './transport/api'
 
-@Service()
 export class Fatzebra extends BaseGateway<FatzebraConfig> implements
   OnceOffPayment,
   RecurringPayment,
   CustomerDetails
 {
   private api: FatzebraAPI
-
-  private settingsManager: SettingsManager
 
   protected get baseConfig(): FatzebraConfig {
     return {
@@ -43,8 +39,6 @@ export class Fatzebra extends BaseGateway<FatzebraConfig> implements
   constructor(config: FatzebraConfig) {
     super(config)
     this.api = new FatzebraAPI(config)
-
-    this.settingsManager = Container.get(SettingsManager)
   }
 
   get name(): string {

--- a/packages/nodepay-pay-way/package.json
+++ b/packages/nodepay-pay-way/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-pay-way",
-  "version": "0.10.9",
+  "version": "0.11.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",
@@ -65,7 +65,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@atomixdesign/nodepay-core": "^0.10.9",
+    "@atomixdesign/nodepay-core": "^0.11.0",
     "@types/debug": "^4.1.5",
     "@types/qs": "^6.9.5",
     "@types/uuid": "^8.3.0",

--- a/packages/nodepay-paystream/package.json
+++ b/packages/nodepay-paystream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomixdesign/nodepay-paystream",
-  "version": "0.10.9",
+  "version": "0.11.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",
@@ -65,7 +65,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@atomixdesign/nodepay-core": "^0.10.9",
+    "@atomixdesign/nodepay-core": "^0.11.0",
     "@types/debug": "^4.1.5",
     "axios": "^0.21.1",
     "class-validator": "^0.13.1",


### PR DESCRIPTION
See https://github.com/typestack/routing-controllers/issues/642

Change in typedi `^0.9.0` appears to break the detection of services registered in `nodepay-core`. Issue is not addressed with even the `@Service` decorator on every participating class, hinting at a possible issue with the mechanism, ie. a bug in typedi.

As a workaround, this PR converts the settings manager into a base gateway instance member, rendering it available to each gateway strategy separately. Dependency injection is still preferred, and should be investigated separately.