### PR TITLE
Make email field optional on FatZebra customer

### DIFF
--- a/packages/nodepay-fatzebra/src/transport/dtos/customer.ts
+++ b/packages/nodepay-fatzebra/src/transport/dtos/customer.ts
@@ -69,6 +69,7 @@ export class CustomerDTO {
   readonly reference: string;
 
   // * email
+  @IsOptional()
   @IsEmail(undefined, {
     message: ErrorFactory.getErrorMessage(ErrorType.NotAnEmail, 'email')
   })


### PR DESCRIPTION
Field is not required on the FatZebra API itself. See:
https://docs.fatzebra.com/reference/create-a-customer